### PR TITLE
Fixed issue with non-relative paths

### DIFF
--- a/lib/jessie/finder.js
+++ b/lib/jessie/finder.js
@@ -1,13 +1,20 @@
 var fs = require('fs');
 
+function abs_path(file_or_dir, base_path) {
+  var path = require('path');
+  if (base_path) {
+    return path.resolve(base_path, file_or_dir);
+  } 
+  return path.resolve(file_or_dir);
+}
+
 exports.finder = function() {
   this.find = function(files_or_dirs, path) {
-    path = path || '.'
     var regex  = /_spec\.js$/
     var specs  = [];
     var finder = this;
     files_or_dirs.forEach(function(file_or_dir) {
-      file_or_dir = path + '/' + file_or_dir
+      file_or_dir = abs_path(file_or_dir, path);
       var stat = fs.statSync(file_or_dir);
       if (stat.isFile() && regex.test(file_or_dir)) {
         specs.push(file_or_dir)

--- a/spec/jessie/finder_spec.js
+++ b/spec/jessie/finder_spec.js
@@ -1,9 +1,14 @@
 describe('jessie.finder', function() {
+  var path = require('path');
   var finder = new (require('jessie/finder').finder)()
   
   it("should find files if only dir is specified", function() {
     finder.find(['spec']).length.should_be(8)
   })
+
+  it('leaves non-relative paths alone', function() {
+    finder.find([path.resolve('spec')]).length.should_be(8)
+  });
   
   it("should find files if only files are specified", function() {
     finder.find(['spec/jessie/finder_spec.js', 'spec/jessie/sugar_spec.js']).length.should_be(2)


### PR DESCRIPTION
All paths in finder.js are now made absolute only if not already absolute, and resolved using path.resolve.
