### PR TITLE
Extend sugar to support booleans

### DIFF
--- a/lib/jessie/sugar.js
+++ b/lib/jessie/sugar.js
@@ -2,9 +2,11 @@
 exports.sugar = function() {
   var Sugar = {
     should_be:                    function(compare) { expect(this).toEqual(compare); },
+    should_be_value:              function(compare) { expect(this.valueOf()).toEqual(compare.valueOf()); },
     should_be_a:                  function(object)  { expect(this.constructor).toEqual(object) },
     should_be_an_instance_of:     function(object)  { expect(true).toEqual(this instanceof(object)) },
     should_not_be:                function(compare) { expect(this).not.toEqual(compare); },
+    should_not_be_value:          function(compare) { expect(this.valueOf()).not.toEqual(compare.valueOf()); },
     should_match:                 function(compare) { expect(this).toMatch(compare); },
     should_not_match:             function(compare) { expect(this).not.toMatch(compare); },
     should_have_been_called:      function()        { expect(this).toHaveBeenCalled(); },
@@ -18,14 +20,17 @@ exports.sugar = function() {
   String.prototype.emitJasmine      = function() { return this };
   Number.prototype.emitJasmine      = function() { return this };
   Array.prototype.emitJasmine       = function() { return this };
+  Boolean.prototype.emitJasmine     = function() { return this };
 
   String.prototype.should_be        = Sugar.should_be
   Number.prototype.should_be        = Sugar.should_be
   Array.prototype.should_be         = Sugar.should_be
+  Boolean.prototype.should_be       = Sugar.should_be_value
 
   String.prototype.should_not_be    = Sugar.should_not_be
   Number.prototype.should_not_be    = Sugar.should_not_be
   Array.prototype.should_not_be     = Sugar.should_not_be
+  Boolean.prototype.should_not_be   = Sugar.should_not_be_value
 
   String.prototype.should_be_a      = Sugar.should_be_a
   Number.prototype.should_be_a      = Sugar.should_be_a


### PR DESCRIPTION
This lets syntax like:  "true.should_be(true)" and "false.should_not_be(true)" to work properly.
