### PR TITLE
Fixed deprecation warning

### DIFF
--- a/lib/jessie/runner.js
+++ b/lib/jessie/runner.js
@@ -6,7 +6,7 @@ exports.runner = function(args, options, callback) {
     var specs   = this.finder.find(args, process.cwd())
     var runner  = this;
     var spec_helper = process.cwd() + '/spec/spec_helper.js'
-    if (require('path').existsSync(spec_helper))
+    if (require('fs').existsSync(spec_helper))
       require(spec_helper)
     specs.forEach(function(spec) { require(spec); })
     this.jasmine.reporter = this.reporter


### PR DESCRIPTION
changed require('path').existsSync to require('fs').existsSync in runner.js
